### PR TITLE
Extend py_converter for integer types and issues

### DIFF
--- a/src/c2py/converters/basic_types.hpp
+++ b/src/c2py/converters/basic_types.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include "../py_converter.hpp"
 #include "../pyref.hpp"
 #include "../util/numpy_includer.hpp"
@@ -62,38 +64,93 @@ namespace c2py {
 
       static constexpr const char *tp_name = "int";
 
-      static PyObject *c2py(I i) { return PyLong_FromLong(long(i)); }
+      static PyObject *c2py(I i) {
+        if constexpr (std::is_signed_v<I>) {
+          return PyLong_FromLongLong(static_cast<long long>(i));
+        } else {
+          return PyLong_FromUnsignedLongLong(static_cast<unsigned long long>(i));
+        }
+      }
+
       static I py2c(PyObject *ob) {
-        if (PyLong_Check(ob)) { return I(PyLong_AsLong(ob)); }
+        if (PyLong_Check(ob)) {
+          if constexpr (std::is_signed_v<I>) {
+            return static_cast<I>(PyLong_AsLongLong(ob));
+          } else {
+            return static_cast<I>(PyLong_AsUnsignedLongLong(ob));
+          }
+        }
         // Convert NPY Scalar Type to Builtin Type
         pyref py_builtin = PyObject_CallMethod(ob, "item", nullptr); //NOLINT
-        return I(PyLong_AsLong(py_builtin));
+        if constexpr (std::is_signed_v<I>) {
+          return static_cast<I>(PyLong_AsLongLong(py_builtin));
+        } else {
+          return static_cast<I>(PyLong_AsUnsignedLongLong(py_builtin));
+        }
       }
+
       static bool is_convertible(PyObject *ob, bool raise_exception) {
         // first check if ob is a python long
         if (PyLong_Check(ob)) {
-          // now check that the int from python is within the limits of the C++ type
-          if (PyLong_AsLong(ob) < std::numeric_limits<I>::min() or PyLong_AsLong(ob) > std::numeric_limits<I>::max()) {
+          // Get value using appropriate Python C API function
+          auto val = [&]() {
+            if constexpr (std::is_signed_v<I>) {
+              return PyLong_AsLongLong(ob);
+            } else {
+              return PyLong_AsUnsignedLongLong(ob);
+            }
+          }();
+
+          // Check for Python errors (e.g., value out of range for long long)
+          if (PyErr_Occurred()) {
+            // Error is already set with appropriate message by PyLong_As*
+            if (not raise_exception) PyErr_Clear();
+            return false;
+          }
+
+          // Check that the value is within the limits of the target C++ type
+          auto min_val = static_cast<decltype(val)>(std::numeric_limits<I>::min());
+          auto max_val = static_cast<decltype(val)>(std::numeric_limits<I>::max());
+          if (val < min_val or val > max_val) {
             if (raise_exception) {
               PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to integer type, out of bounds"s).c_str());
             }
             return false;
-          } else
-            return true;
+          }
+          return true;
         }
 
+        // Check NumPy scalar types
         if (PyArray_CheckScalar(ob)) {
           pyref py_arr = PyArray_FromScalar(ob, nullptr);
-          if (PyArray_ISINTEGER((PyArrayObject *)(PyObject *)py_arr)) return true; //NOLINT
+          if (PyArray_ISINTEGER((PyArrayObject *)(PyObject *)py_arr)) {
+            // Convert NumPy scalar to Python int and check bounds
+            pyref py_int = PyObject_CallMethod(ob, "item", nullptr);
+            if (not py_int) {
+              if (not raise_exception) PyErr_Clear();
+              return false;
+            }
+            // Recursively check if the converted Python int is valid
+            return is_convertible(py_int, raise_exception);
+          }
         }
+
         if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to integer type"s).c_str()); }
         return false;
       }
     };
   } // namespace details
 
-  template <> struct py_converter<long> : details::py_converter_impl<long> {};
+  // Integer types
+  // Note: Fixed-width types (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t)
+  // are typedefs to the standard types below and are automatically supported.
+  template <> struct py_converter<signed char> : details::py_converter_impl<signed char> {};
+  template <> struct py_converter<short> : details::py_converter_impl<short> {};
   template <> struct py_converter<int> : details::py_converter_impl<int> {};
+  template <> struct py_converter<long> : details::py_converter_impl<long> {};
+  template <> struct py_converter<long long> : details::py_converter_impl<long long> {};
+  template <> struct py_converter<unsigned char> : details::py_converter_impl<unsigned char> {};
+  template <> struct py_converter<unsigned short> : details::py_converter_impl<unsigned short> {};
   template <> struct py_converter<unsigned int> : details::py_converter_impl<unsigned int> {};
   template <> struct py_converter<unsigned long> : details::py_converter_impl<unsigned long> {};
   template <> struct py_converter<unsigned long long> : details::py_converter_impl<unsigned long long> {};

--- a/src/c2py/converters/stl/string.hpp
+++ b/src/c2py/converters/stl/string.hpp
@@ -48,18 +48,8 @@ namespace c2py {
     }
   };
 
-  template <> struct py_converter<unsigned char> {
-
-    static PyObject *c2py(unsigned char c) { return PyBytes_FromStringAndSize(reinterpret_cast<char *>(&c), 1); } // NOLINT
-
-    static unsigned char py2c(PyObject *ob) { return static_cast<unsigned char>(PyBytes_AsString(ob)[0]); } // NOLINT
-
-    static bool is_convertible(PyObject *ob, bool raise_exception) {
-      if (PyBytes_Check(ob) and PyBytes_Size(ob) == 1) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to unsigned char"s).c_str()); }
-      return false;
-    }
-  };
+  // Note: unsigned char (uint8_t) is treated as an integer type, not a character type
+  // See basic_types.hpp for the integer converter. Use std::byte for byte operations.
 
   template <> struct py_converter<const char *> {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ endmacro()
 c2py_add_test(cls LOW_LEVEL)
 set (c2py_all_low_level_tests cls CACHE INTERNAL "") # Keep this, used in clair 
 
-set(c2py_all_full_tests 
+set(c2py_all_full_tests
   any
   basicfun
   bug_tpl_type
@@ -51,6 +51,7 @@ set(c2py_all_full_tests
   ignore
   generator
   enumcxx
+  integers
   synth_init
   tpl_cls
   tpl_derived

--- a/test/integers.cpp
+++ b/test/integers.cpp
@@ -1,0 +1,54 @@
+#include <c2py/c2py.hpp>
+#include <cstdint>
+#include <limits>
+
+// Test functions for fixed-width signed types
+int8_t identity_int8(int8_t x) { return x; }
+int16_t identity_int16(int16_t x) { return x; }
+int32_t identity_int32(int32_t x) { return x; }
+int64_t identity_int64(int64_t x) { return x; }
+
+// Test functions for fixed-width unsigned types
+uint8_t identity_uint8(uint8_t x) { return x; }
+uint16_t identity_uint16(uint16_t x) { return x; }
+uint32_t identity_uint32(uint32_t x) { return x; }
+uint64_t identity_uint64(uint64_t x) { return x; }
+
+// Test functions for standard types
+short identity_short(short x) { return x; }
+unsigned short identity_ushort(unsigned short x) { return x; }
+long long identity_longlong(long long x) { return x; }
+
+// Test function for size_t
+size_t identity_size_t(size_t x) { return x; }
+
+// Functions that return boundary values
+int8_t get_int8_min() { return std::numeric_limits<int8_t>::min(); }
+int8_t get_int8_max() { return std::numeric_limits<int8_t>::max(); }
+uint8_t get_uint8_max() { return std::numeric_limits<uint8_t>::max(); }
+
+int16_t get_int16_min() { return std::numeric_limits<int16_t>::min(); }
+int16_t get_int16_max() { return std::numeric_limits<int16_t>::max(); }
+uint16_t get_uint16_max() { return std::numeric_limits<uint16_t>::max(); }
+
+int32_t get_int32_min() { return std::numeric_limits<int32_t>::min(); }
+int32_t get_int32_max() { return std::numeric_limits<int32_t>::max(); }
+uint32_t get_uint32_max() { return std::numeric_limits<uint32_t>::max(); }
+
+int64_t get_int64_min() { return std::numeric_limits<int64_t>::min(); }
+int64_t get_int64_max() { return std::numeric_limits<int64_t>::max(); }
+uint64_t get_uint64_max() { return std::numeric_limits<uint64_t>::max(); }
+
+short get_short_min() { return std::numeric_limits<short>::min(); }
+short get_short_max() { return std::numeric_limits<short>::max(); }
+unsigned short get_ushort_max() { return std::numeric_limits<unsigned short>::max(); }
+
+long long get_longlong_min() { return std::numeric_limits<long long>::min(); }
+long long get_longlong_max() { return std::numeric_limits<long long>::max(); }
+
+// Arithmetic operations to test conversion
+int16_t add_int16(int16_t a, int16_t b) { return a + b; }
+uint32_t add_uint32(uint32_t a, uint32_t b) { return a + b; }
+int64_t multiply_int64(int64_t a, int64_t b) { return a * b; }
+
+#include "integers.wrap.cxx"

--- a/test/integers.wrap.cxx
+++ b/test/integers.wrap.cxx
@@ -1,0 +1,234 @@
+
+// C.f. https://numpy.org/doc/1.21/reference/c-api/array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL _cpp2py_ARRAY_API
+#ifndef CLAIR_C2PY_WRAP_GEN
+#ifdef __clang__
+// #pragma clang diagnostic ignored "-W#warnings"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
+
+#define C2PY_VERSION_MAJOR 0
+#define C2PY_VERSION_MINOR 1
+
+#include <c2py/c2py.hpp>
+
+using c2py::operator""_a;
+
+// ==================== Wrapped classes =====================
+
+// ==================== enums =====================
+
+// ==================== module classes =====================
+
+// ==================== module functions ====================
+
+// add_int16
+static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cfun([](short a, short b) { return add_int16(a, b); }, "a", "b")};
+
+// add_uint32
+static auto const fun_1 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned int a, unsigned int b) { return add_uint32(a, b); }, "a", "b")};
+
+// get_int16_max
+static auto const fun_2 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int16_max(); })};
+
+// get_int16_min
+static auto const fun_3 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int16_min(); })};
+
+// get_int32_max
+static auto const fun_4 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int32_max(); })};
+
+// get_int32_min
+static auto const fun_5 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int32_min(); })};
+
+// get_int64_max
+static auto const fun_6 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int64_max(); })};
+
+// get_int64_min
+static auto const fun_7 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int64_min(); })};
+
+// get_longlong_max
+static auto const fun_8 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_longlong_max(); })};
+
+// get_longlong_min
+static auto const fun_9 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_longlong_min(); })};
+
+// get_short_max
+static auto const fun_10 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_short_max(); })};
+
+// get_short_min
+static auto const fun_11 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_short_min(); })};
+
+// get_uint16_max
+static auto const fun_12 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_uint16_max(); })};
+
+// get_uint32_max
+static auto const fun_13 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_uint32_max(); })};
+
+// get_uint64_max
+static auto const fun_14 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_uint64_max(); })};
+
+// get_ushort_max
+static auto const fun_15 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_ushort_max(); })};
+
+// identity_int16
+static auto const fun_16 = c2py::dispatcher_f_kw_t{c2py::cfun([](short x) { return identity_int16(x); }, "x")};
+
+// identity_int32
+static auto const fun_17 = c2py::dispatcher_f_kw_t{c2py::cfun([](int x) { return identity_int32(x); }, "x")};
+
+// identity_int64
+static auto const fun_18 = c2py::dispatcher_f_kw_t{c2py::cfun([](long x) { return identity_int64(x); }, "x")};
+
+// identity_longlong
+static auto const fun_19 = c2py::dispatcher_f_kw_t{c2py::cfun([](long long x) { return identity_longlong(x); }, "x")};
+
+// identity_short
+static auto const fun_20 = c2py::dispatcher_f_kw_t{c2py::cfun([](short x) { return identity_short(x); }, "x")};
+
+// identity_size_t
+static auto const fun_21 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned long x) { return identity_size_t(x); }, "x")};
+
+// identity_uint16
+static auto const fun_22 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned short x) { return identity_uint16(x); }, "x")};
+
+// identity_uint32
+static auto const fun_23 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned int x) { return identity_uint32(x); }, "x")};
+
+// identity_uint64
+static auto const fun_24 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned long x) { return identity_uint64(x); }, "x")};
+
+// identity_ushort
+static auto const fun_25 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned short x) { return identity_ushort(x); }, "x")};
+
+// multiply_int64
+static auto const fun_26 = c2py::dispatcher_f_kw_t{c2py::cfun([](long a, long b) { return multiply_int64(a, b); }, "a", "b")};
+
+// identity_int8
+static auto const fun_27 = c2py::dispatcher_f_kw_t{c2py::cfun([](signed char x) { return identity_int8(x); }, "x")};
+
+// identity_uint8
+static auto const fun_28 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned char x) { return identity_uint8(x); }, "x")};
+
+// get_int8_min
+static auto const fun_29 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int8_min(); })};
+
+// get_int8_max
+static auto const fun_30 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_int8_max(); })};
+
+// get_uint8_max
+static auto const fun_31 = c2py::dispatcher_f_kw_t{c2py::cfun([]() { return get_uint8_max(); })};
+
+static const auto doc_d_0  = fun_0.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_1  = fun_1.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_2  = fun_2.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_3  = fun_3.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_4  = fun_4.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_5  = fun_5.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_6  = fun_6.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_7  = fun_7.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_8  = fun_8.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_9  = fun_9.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_10 = fun_10.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_11 = fun_11.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_12 = fun_12.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_13 = fun_13.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_14 = fun_14.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_15 = fun_15.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_16 = fun_16.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_17 = fun_17.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_18 = fun_18.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_19 = fun_19.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_20 = fun_20.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_21 = fun_21.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_22 = fun_22.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_23 = fun_23.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_24 = fun_24.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_25 = fun_25.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_26 = fun_26.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_27 = fun_27.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_28 = fun_28.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_29 = fun_29.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_30 = fun_30.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_31 = fun_31.doc(R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
+//--------------------- module function table  -----------------------------
+
+static PyMethodDef module_methods[] = {
+   {"add_int16", (PyCFunction)c2py::pyfkw<fun_0>, METH_VARARGS | METH_KEYWORDS, doc_d_0.c_str()},
+   {"add_uint32", (PyCFunction)c2py::pyfkw<fun_1>, METH_VARARGS | METH_KEYWORDS, doc_d_1.c_str()},
+   {"get_int16_max", (PyCFunction)c2py::pyfkw<fun_2>, METH_VARARGS | METH_KEYWORDS, doc_d_2.c_str()},
+   {"get_int16_min", (PyCFunction)c2py::pyfkw<fun_3>, METH_VARARGS | METH_KEYWORDS, doc_d_3.c_str()},
+   {"get_int32_max", (PyCFunction)c2py::pyfkw<fun_4>, METH_VARARGS | METH_KEYWORDS, doc_d_4.c_str()},
+   {"get_int32_min", (PyCFunction)c2py::pyfkw<fun_5>, METH_VARARGS | METH_KEYWORDS, doc_d_5.c_str()},
+   {"get_int64_max", (PyCFunction)c2py::pyfkw<fun_6>, METH_VARARGS | METH_KEYWORDS, doc_d_6.c_str()},
+   {"get_int64_min", (PyCFunction)c2py::pyfkw<fun_7>, METH_VARARGS | METH_KEYWORDS, doc_d_7.c_str()},
+   {"get_longlong_max", (PyCFunction)c2py::pyfkw<fun_8>, METH_VARARGS | METH_KEYWORDS, doc_d_8.c_str()},
+   {"get_longlong_min", (PyCFunction)c2py::pyfkw<fun_9>, METH_VARARGS | METH_KEYWORDS, doc_d_9.c_str()},
+   {"get_short_max", (PyCFunction)c2py::pyfkw<fun_10>, METH_VARARGS | METH_KEYWORDS, doc_d_10.c_str()},
+   {"get_short_min", (PyCFunction)c2py::pyfkw<fun_11>, METH_VARARGS | METH_KEYWORDS, doc_d_11.c_str()},
+   {"get_uint16_max", (PyCFunction)c2py::pyfkw<fun_12>, METH_VARARGS | METH_KEYWORDS, doc_d_12.c_str()},
+   {"get_uint32_max", (PyCFunction)c2py::pyfkw<fun_13>, METH_VARARGS | METH_KEYWORDS, doc_d_13.c_str()},
+   {"get_uint64_max", (PyCFunction)c2py::pyfkw<fun_14>, METH_VARARGS | METH_KEYWORDS, doc_d_14.c_str()},
+   {"get_ushort_max", (PyCFunction)c2py::pyfkw<fun_15>, METH_VARARGS | METH_KEYWORDS, doc_d_15.c_str()},
+   {"identity_int16", (PyCFunction)c2py::pyfkw<fun_16>, METH_VARARGS | METH_KEYWORDS, doc_d_16.c_str()},
+   {"identity_int32", (PyCFunction)c2py::pyfkw<fun_17>, METH_VARARGS | METH_KEYWORDS, doc_d_17.c_str()},
+   {"identity_int64", (PyCFunction)c2py::pyfkw<fun_18>, METH_VARARGS | METH_KEYWORDS, doc_d_18.c_str()},
+   {"identity_longlong", (PyCFunction)c2py::pyfkw<fun_19>, METH_VARARGS | METH_KEYWORDS, doc_d_19.c_str()},
+   {"identity_short", (PyCFunction)c2py::pyfkw<fun_20>, METH_VARARGS | METH_KEYWORDS, doc_d_20.c_str()},
+   {"identity_size_t", (PyCFunction)c2py::pyfkw<fun_21>, METH_VARARGS | METH_KEYWORDS, doc_d_21.c_str()},
+   {"identity_uint16", (PyCFunction)c2py::pyfkw<fun_22>, METH_VARARGS | METH_KEYWORDS, doc_d_22.c_str()},
+   {"identity_uint32", (PyCFunction)c2py::pyfkw<fun_23>, METH_VARARGS | METH_KEYWORDS, doc_d_23.c_str()},
+   {"identity_uint64", (PyCFunction)c2py::pyfkw<fun_24>, METH_VARARGS | METH_KEYWORDS, doc_d_24.c_str()},
+   {"identity_ushort", (PyCFunction)c2py::pyfkw<fun_25>, METH_VARARGS | METH_KEYWORDS, doc_d_25.c_str()},
+   {"multiply_int64", (PyCFunction)c2py::pyfkw<fun_26>, METH_VARARGS | METH_KEYWORDS, doc_d_26.c_str()},
+   {"identity_int8", (PyCFunction)c2py::pyfkw<fun_27>, METH_VARARGS | METH_KEYWORDS, doc_d_27.c_str()},
+   {"identity_uint8", (PyCFunction)c2py::pyfkw<fun_28>, METH_VARARGS | METH_KEYWORDS, doc_d_28.c_str()},
+   {"get_int8_min", (PyCFunction)c2py::pyfkw<fun_29>, METH_VARARGS | METH_KEYWORDS, doc_d_29.c_str()},
+   {"get_int8_max", (PyCFunction)c2py::pyfkw<fun_30>, METH_VARARGS | METH_KEYWORDS, doc_d_30.c_str()},
+   {"get_uint8_max", (PyCFunction)c2py::pyfkw<fun_31>, METH_VARARGS | METH_KEYWORDS, doc_d_31.c_str()},
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+//--------------------- module struct & init error definition ------------
+
+//// module doc directly in the code or "" if not present...
+/// Or mandatory ?
+static struct PyModuleDef module_def = {PyModuleDef_HEAD_INIT,
+                                        "integers",        /* name of module */
+                                        R"RAWDOC()RAWDOC", /* module documentation, may be NULL */
+                                        -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+                                        module_methods,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL};
+
+//--------------------- module init function -----------------------------
+
+extern "C" __attribute__((visibility("default"))) PyObject *PyInit_integers() {
+
+  if (not c2py::check_python_version("integers")) return NULL;
+
+  // import numpy iff 'numpy/arrayobject.h' included
+#ifdef Py_ARRAYOBJECT_H
+  import_array();
+#endif
+
+  PyObject *m;
+
+  if (PyType_Ready(&c2py::wrap_pytype<c2py::py_range>) < 0) return NULL;
+
+  m = PyModule_Create(&module_def);
+  if (m == NULL) return NULL;
+
+  auto &conv_table = *c2py::conv_table_sptr.get();
+
+  conv_table[std::type_index(typeid(c2py::py_range)).name()] = &c2py::wrap_pytype<c2py::py_range>;
+
+  return m;
+}
+#endif
+// CLAIR_WRAP_GEN

--- a/test/integers.wrap.hxx
+++ b/test/integers.wrap.hxx
@@ -1,0 +1,6 @@
+#include <c2py/c2py.hpp>
+
+#ifndef C2PY_HXX_DECLARATION_integers_GUARDS
+#define C2PY_HXX_DECLARATION_integers_GUARDS
+
+#endif

--- a/test/integers_test.py
+++ b/test/integers_test.py
@@ -1,0 +1,176 @@
+import unittest
+import numpy as np
+
+import integers as I
+
+class TestIntegerTypes(unittest.TestCase):
+
+    # Test fixed-width signed types
+    def test_int8(self):
+        self.assertEqual(I.identity_int8(0), 0)
+        self.assertEqual(I.identity_int8(127), 127)
+        self.assertEqual(I.identity_int8(-128), -128)
+        self.assertEqual(I.get_int8_min(), -128)
+        self.assertEqual(I.get_int8_max(), 127)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_int8, 128)
+        self.assertRaises(TypeError, I.identity_int8, -129)
+
+    def test_int16(self):
+        self.assertEqual(I.identity_int16(0), 0)
+        self.assertEqual(I.identity_int16(32767), 32767)
+        self.assertEqual(I.identity_int16(-32768), -32768)
+        self.assertEqual(I.get_int16_min(), -32768)
+        self.assertEqual(I.get_int16_max(), 32767)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_int16, 32768)
+        self.assertRaises(TypeError, I.identity_int16, -32769)
+
+    def test_int32(self):
+        self.assertEqual(I.identity_int32(0), 0)
+        self.assertEqual(I.identity_int32(2147483647), 2147483647)
+        self.assertEqual(I.identity_int32(-2147483648), -2147483648)
+        self.assertEqual(I.get_int32_min(), -2147483648)
+        self.assertEqual(I.get_int32_max(), 2147483647)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_int32, 2147483648)
+        self.assertRaises(TypeError, I.identity_int32, -2147483649)
+
+    def test_int64(self):
+        self.assertEqual(I.identity_int64(0), 0)
+        self.assertEqual(I.identity_int64(9223372036854775807), 9223372036854775807)
+        self.assertEqual(I.identity_int64(-9223372036854775808), -9223372036854775808)
+        self.assertEqual(I.get_int64_min(), -9223372036854775808)
+        self.assertEqual(I.get_int64_max(), 9223372036854775807)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_int64, 9223372036854775808)
+        self.assertRaises(TypeError, I.identity_int64, -9223372036854775809)
+
+    # Test fixed-width unsigned types
+    def test_uint8(self):
+        self.assertEqual(I.identity_uint8(0), 0)
+        self.assertEqual(I.identity_uint8(255), 255)
+        self.assertEqual(I.get_uint8_max(), 255)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_uint8, 256)
+        self.assertRaises(TypeError, I.identity_uint8, -1)
+
+    def test_uint16(self):
+        self.assertEqual(I.identity_uint16(0), 0)
+        self.assertEqual(I.identity_uint16(65535), 65535)
+        self.assertEqual(I.get_uint16_max(), 65535)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_uint16, 65536)
+        self.assertRaises(TypeError, I.identity_uint16, -1)
+
+    def test_uint32(self):
+        self.assertEqual(I.identity_uint32(0), 0)
+        self.assertEqual(I.identity_uint32(4294967295), 4294967295)
+        self.assertEqual(I.get_uint32_max(), 4294967295)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_uint32, 4294967296)
+        self.assertRaises(TypeError, I.identity_uint32, -1)
+
+    def test_uint64(self):
+        self.assertEqual(I.identity_uint64(0), 0)
+        self.assertEqual(I.identity_uint64(18446744073709551615), 18446744073709551615)
+        self.assertEqual(I.get_uint64_max(), 18446744073709551615)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_uint64, 18446744073709551616)
+        self.assertRaises(TypeError, I.identity_uint64, -1)
+
+    # Test standard types
+    def test_short(self):
+        self.assertEqual(I.identity_short(0), 0)
+        min_val = I.get_short_min()
+        max_val = I.get_short_max()
+        self.assertEqual(I.identity_short(min_val), min_val)
+        self.assertEqual(I.identity_short(max_val), max_val)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_short, max_val + 1)
+        self.assertRaises(TypeError, I.identity_short, min_val - 1)
+
+    def test_unsigned_short(self):
+        self.assertEqual(I.identity_ushort(0), 0)
+        max_val = I.get_ushort_max()
+        self.assertEqual(I.identity_ushort(max_val), max_val)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_ushort, max_val + 1)
+        self.assertRaises(TypeError, I.identity_ushort, -1)
+
+    def test_long_long(self):
+        self.assertEqual(I.identity_longlong(0), 0)
+        min_val = I.get_longlong_min()
+        max_val = I.get_longlong_max()
+        self.assertEqual(I.identity_longlong(min_val), min_val)
+        self.assertEqual(I.identity_longlong(max_val), max_val)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_longlong, max_val + 1)
+        self.assertRaises(TypeError, I.identity_longlong, min_val - 1)
+
+    # Test size_t
+    def test_size_t(self):
+        self.assertEqual(I.identity_size_t(0), 0)
+        self.assertEqual(I.identity_size_t(1000), 1000)
+        # Test large value (should work on 64-bit systems)
+        self.assertEqual(I.identity_size_t(0xFFFFFFFF), 0xFFFFFFFF)
+        # Test overflow protection
+        self.assertRaises(TypeError, I.identity_size_t, -1)
+
+    # Test arithmetic operations
+    def test_add_int16(self):
+        self.assertEqual(I.add_int16(100, 200), 300)
+        self.assertEqual(I.add_int16(-100, 50), -50)
+        self.assertEqual(I.add_int16(0, 0), 0)
+
+    def test_add_uint32(self):
+        self.assertEqual(I.add_uint32(1000, 2000), 3000)
+        self.assertEqual(I.add_uint32(0, 100), 100)
+        self.assertEqual(I.add_uint32(0xFFFFFFFF, 0), 0xFFFFFFFF)
+
+    def test_multiply_int64(self):
+        self.assertEqual(I.multiply_int64(100, 200), 20000)
+        self.assertEqual(I.multiply_int64(-100, 50), -5000)
+        self.assertEqual(I.multiply_int64(0, 12345), 0)
+
+    # Test NumPy scalar conversions
+    def test_numpy_int8(self):
+        val = np.int8(42)
+        self.assertEqual(I.identity_int8(val), 42)
+
+    def test_numpy_uint8(self):
+        val = np.uint8(200)
+        self.assertEqual(I.identity_uint8(val), 200)
+
+    def test_numpy_uint32(self):
+        val = np.uint32(12345)
+        self.assertEqual(I.identity_uint32(val), 12345)
+
+    def test_numpy_int64(self):
+        val = np.int64(-999999)
+        self.assertEqual(I.identity_int64(val), -999999)
+
+    # Test NumPy scalar overflow protection
+    def test_numpy_int64_to_int8_overflow(self):
+        # np.int64(1000) should not fit in int8_t (range -128 to 127)
+        val = np.int64(1000)
+        self.assertRaises(TypeError, I.identity_int8, val)
+
+    def test_numpy_uint32_to_uint8_overflow(self):
+        # np.uint32(1000) should not fit in uint8_t (range 0 to 255)
+        val = np.uint32(1000)
+        self.assertRaises(TypeError, I.identity_uint8, val)
+
+    # Test round-trip conversions
+    def test_roundtrip_int16(self):
+        values = [-32768, -1000, 0, 1000, 32767]
+        for val in values:
+            self.assertEqual(I.identity_int16(val), val)
+
+    def test_roundtrip_uint64(self):
+        values = [0, 1, 1000, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFF]
+        for val in values:
+            self.assertEqual(I.identity_uint64(val), val)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Fix incorrect Python C API usage for unsigned and long long types (was using PyLong_FromLong/PyLong_AsLong for all types)
- Add support for all standard integer types: signed char, unsigned char, short, unsigned short, long long (int8_t through uint64_t via typedefs)
- Implement proper bounds checking with NumPy scalar validation
- Change unsigned char from bytes to integer converter (breaking change)
- Add comprehensive integer type test suite (23 tests)
- Use elegant if constexpr lambda pattern for type dispatch

BREAKING CHANGE: unsigned char (uint8_t) now converts to/from Python int instead of bytes. Use std::byte for byte operations.