### PR TITLE
Fix issue when capturing default args by const ref

### DIFF
--- a/src/c2py/dyn_dispatch/pycfun_kw.hpp
+++ b/src/c2py/dyn_dispatch/pycfun_kw.hpp
@@ -127,12 +127,12 @@ namespace c2py {
     template <typename T> decltype(auto) arg_cast(int pos, PyObject *args, PyObject *kwargs) const {
       using conv_t = py_converter<std::decay_t<T>>;
       PyObject *p  = get_pyarg(pos, args, kwargs);
-      if constexpr (std::is_reference_v<T> and not std::is_const_v<T>) {
+      if constexpr (std::is_reference_v<T> and not std::is_const_v<std::remove_reference_t<T>>) {
         return conv_t::py2c(p);
       } else {
         using conv_r_t = decltype(conv_t::py2c(p));
-        static_assert(std::is_same_v<std::decay_t<conv_r_t>, T>);
-        using r_t = std::conditional_t<std::is_reference_v<conv_r_t>, T const &, T>;
+        static_assert(std::is_same_v<std::decay_t<conv_r_t>, std::decay_t<T>>);
+        using r_t = std::conditional_t<std::is_reference_v<conv_r_t>, std::decay_t<T> const &, std::decay_t<T>>;
         // ensure return type if the same in both branch, as fixed by the converter.
         if (p != nullptr)
           return static_cast<r_t>(conv_t::py2c(p));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(c2py_all_full_tests
   two_module_1
   two_module_2
   refcount
+  const_ref_default_arg
   CACHE INTERNAL "")
 
 foreach(t ${c2py_all_full_tests})

--- a/test/const_ref_default_arg.cpp
+++ b/test/const_ref_default_arg.cpp
@@ -1,0 +1,8 @@
+#include <c2py/c2py.hpp>
+
+#include <string>
+
+int f1(int const& x = 5) { return 2 + x; }
+std::string f2(std::string const& s = "hello") { return s + " world"; }
+
+#include "const_ref_default_arg.wrap.cxx"

--- a/test/const_ref_default_arg.wrap.cxx
+++ b/test/const_ref_default_arg.wrap.cxx
@@ -1,0 +1,84 @@
+
+// C.f. https://numpy.org/doc/1.21/reference/c-api/array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL _cpp2py_ARRAY_API
+#ifndef CLAIR_C2PY_WRAP_GEN
+#ifdef __clang__
+// #pragma clang diagnostic ignored "-W#warnings"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
+
+#define C2PY_VERSION_MAJOR 0
+#define C2PY_VERSION_MINOR 1
+
+#include <c2py/c2py.hpp>
+
+using c2py::operator""_a;
+
+// ==================== Wrapped classes =====================
+
+// ==================== enums =====================
+
+// ==================== module classes =====================
+
+// ==================== module functions ====================
+
+// f1
+static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cfun([](int const &x) { return f1(x); }, "x"_a = 5)};
+
+// f2
+static auto const fun_1 = c2py::dispatcher_f_kw_t{c2py::cfun([](const std::string &s) { return f2(s); }, "s"_a = "hello")};
+
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
+//--------------------- module function table  -----------------------------
+
+static PyMethodDef module_methods[] = {
+   {"f1", (PyCFunction)c2py::pyfkw<fun_0>, METH_VARARGS | METH_KEYWORDS, doc_d_0.c_str()},
+   {"f2", (PyCFunction)c2py::pyfkw<fun_1>, METH_VARARGS | METH_KEYWORDS, doc_d_1.c_str()},
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+//--------------------- module struct & init error definition ------------
+
+//// module doc directly in the code or "" if not present...
+/// Or mandatory ?
+static struct PyModuleDef module_def = {PyModuleDef_HEAD_INIT,
+                                        "const_ref_default_arg", /* name of module */
+                                        R"RAWDOC()RAWDOC",       /* module documentation, may be NULL */
+                                        -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+                                        module_methods,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL};
+
+//--------------------- module init function -----------------------------
+
+extern "C" __attribute__((visibility("default"))) PyObject *PyInit_const_ref_default_arg() {
+
+  if (not c2py::check_python_version("const_ref_default_arg")) return NULL;
+
+  // import numpy iff 'numpy/arrayobject.h' included
+#ifdef Py_ARRAYOBJECT_H
+  import_array();
+#endif
+
+  PyObject *m;
+
+  if (PyType_Ready(&c2py::wrap_pytype<c2py::py_range>) < 0) return NULL;
+
+  m = PyModule_Create(&module_def);
+  if (m == NULL) return NULL;
+
+  auto &conv_table = *c2py::conv_table_sptr.get();
+
+  conv_table[std::type_index(typeid(c2py::py_range)).name()] = &c2py::wrap_pytype<c2py::py_range>;
+
+  return m;
+}
+#endif
+// CLAIR_WRAP_GEN

--- a/test/const_ref_default_arg.wrap.hxx
+++ b/test/const_ref_default_arg.wrap.hxx
@@ -1,0 +1,6 @@
+#include <c2py/c2py.hpp>
+
+#ifndef C2PY_HXX_DECLARATION_const_ref_default_arg_GUARDS
+#define C2PY_HXX_DECLARATION_const_ref_default_arg_GUARDS
+
+#endif

--- a/test/const_ref_default_arg_test.py
+++ b/test/const_ref_default_arg_test.py
@@ -1,0 +1,16 @@
+import unittest
+
+from const_ref_default_arg import *
+
+class TestConstRefDefaultArg(unittest.TestCase):
+
+    def test_f1(self):
+        self.assertEqual(f1(), 7)
+        self.assertEqual(f1(10), 12)
+
+    def test_f2(self):
+        self.assertEqual(f2(), "hello world")
+        self.assertEqual(f2("hi"), "hi world")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- add tests to show what does not work
- fix issue
  - arg_cast assumes that `std::is_const_v` is true for const ref
