### PR TITLE
Improve handling of default arguments

### DIFF
--- a/src/c2py/dyn_dispatch/pycfun_kw.hpp
+++ b/src/c2py/dyn_dispatch/pycfun_kw.hpp
@@ -65,7 +65,7 @@ namespace c2py {
     return argument_t{std::move(nvp).name, //
                       python_typename<std::decay_t<A>>,
                       [](PyObject *ob, bool re) -> bool { return py_converter<std::decay_t<A>>::is_convertible(ob, re); }, //
-                      static_cast<A>(std::move(nvp).value), //ensure the default_value is an A, whatever T is.
+                      A(std::move(nvp).value), //ensure the default_value is an A, whatever T is.
                       default_value_repr<A>};
   }
 

--- a/src/c2py/dyn_dispatch/pycfun_kw.hpp
+++ b/src/c2py/dyn_dispatch/pycfun_kw.hpp
@@ -65,7 +65,7 @@ namespace c2py {
     return argument_t{std::move(nvp).name, //
                       python_typename<std::decay_t<A>>,
                       [](PyObject *ob, bool re) -> bool { return py_converter<std::decay_t<A>>::is_convertible(ob, re); }, //
-                      A{std::move(nvp).value}, //ensure the default_value is an A, whatever T is.
+                      static_cast<A>(std::move(nvp).value), //ensure the default_value is an A, whatever T is.
                       default_value_repr<A>};
   }
 

--- a/test/basicfun.cpp
+++ b/test/basicfun.cpp
@@ -110,7 +110,14 @@ void zfoo(std::string x = {}) { std::cout << x << "\n"; }
 int zfwd_decl_fnt(int);
 int zfwd_decl_fnt(int x) { return x + 1; }
 
-int doc_d_1(int){ return 8;}
+int doc_d_1(int) { return 8; }
 
+// Wrap a function with a default argument whose type is an unqualified namespace-scoped alias
+namespace ns {
+
+  using myint_t = long;
+  myint_t zz_defarg_alias2(myint_t v = myint_t{0}) { return v; }
+
+} // namespace ns
 
 #include "basicfun.wrap.cxx"

--- a/test/basicfun.wrap.cxx
+++ b/test/basicfun.wrap.cxx
@@ -101,6 +101,9 @@ static auto const _c2py_fun_12 = c2py::dispatcher_f_kw_t{c2py::cfun([](int x) { 
 // zz
 static auto const _c2py_fun_13 = c2py::dispatcher_f_kw_t{c2py::cfun([](const A &x) { return zz<A>(x); }, "x")};
 
+// zz_defarg_alias2
+static auto const _c2py_fun_14 = c2py::dispatcher_f_kw_t{c2py::cfun([](long v) { return ns::zz_defarg_alias2(v); }, "v"_a = long{0})};
+
 static const auto _c2py_doc_0  = _c2py_fun_0.doc(R"DOC()DOC");
 static const auto _c2py_doc_1  = _c2py_fun_1.doc(R"DOC()DOC");
 static const auto _c2py_doc_2  = _c2py_fun_2.doc(R"DOC()DOC");
@@ -115,6 +118,7 @@ static const auto _c2py_doc_10 = _c2py_fun_10.doc(R"DOC()DOC");
 static const auto _c2py_doc_11 = _c2py_fun_11.doc(R"DOC()DOC");
 static const auto _c2py_doc_12 = _c2py_fun_12.doc(R"DOC()DOC");
 static const auto _c2py_doc_13 = _c2py_fun_13.doc(R"DOC()DOC");
+static const auto _c2py_doc_14 = _c2py_fun_14.doc(R"DOC()DOC");
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {
@@ -132,6 +136,7 @@ static PyMethodDef module_methods[] = {
    {"zfoo", (PyCFunction)c2py::pyfkw<_c2py_fun_11>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_11.c_str()},
    {"zfwd_decl_fnt", (PyCFunction)c2py::pyfkw<_c2py_fun_12>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_12.c_str()},
    {"zz", (PyCFunction)c2py::pyfkw<_c2py_fun_13>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_13.c_str()},
+   {"zz_defarg_alias2", (PyCFunction)c2py::pyfkw<_c2py_fun_14>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_14.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/test/integers.cpp
+++ b/test/integers.cpp
@@ -5,11 +5,13 @@
 int16_t identity_int16(int16_t x) { return x; }
 int32_t identity_int32(int32_t x) { return x; }
 int64_t identity_int64(int64_t x) { return x; }
+int64_t identity_int64_with_defarg(int64_t x = 42) { return x; }
 
 // Test functions for fixed-width unsigned types
 uint16_t identity_uint16(uint16_t x) { return x; }
 uint32_t identity_uint32(uint32_t x) { return x; }
 uint64_t identity_uint64(uint64_t x) { return x; }
+uint64_t identity_uint64_with_defarg(uint64_t x = 42) { return x; }
 
 // Arithmetic operation to test multi-argument conversion
 int16_t add_int16(int16_t a, int16_t b) { return a + b; }

--- a/test/integers.wrap.cxx
+++ b/test/integers.wrap.cxx
@@ -36,14 +36,20 @@ static auto const _c2py_fun_2 = c2py::dispatcher_f_kw_t{c2py::cfun([](int x) { r
 // identity_int64
 static auto const _c2py_fun_3 = c2py::dispatcher_f_kw_t{c2py::cfun([](long long x) { return identity_int64(x); }, "x")};
 
+// identity_int64_with_defarg
+static auto const _c2py_fun_4 = c2py::dispatcher_f_kw_t{c2py::cfun([](long long x) { return identity_int64_with_defarg(x); }, "x"_a = 42)};
+
 // identity_uint16
-static auto const _c2py_fun_4 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned short x) { return identity_uint16(x); }, "x")};
+static auto const _c2py_fun_5 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned short x) { return identity_uint16(x); }, "x")};
 
 // identity_uint32
-static auto const _c2py_fun_5 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned int x) { return identity_uint32(x); }, "x")};
+static auto const _c2py_fun_6 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned int x) { return identity_uint32(x); }, "x")};
 
 // identity_uint64
-static auto const _c2py_fun_6 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned long long x) { return identity_uint64(x); }, "x")};
+static auto const _c2py_fun_7 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned long long x) { return identity_uint64(x); }, "x")};
+
+// identity_uint64_with_defarg
+static auto const _c2py_fun_8 = c2py::dispatcher_f_kw_t{c2py::cfun([](unsigned long long x) { return identity_uint64_with_defarg(x); }, "x"_a = 42)};
 
 static const auto _c2py_doc_0 = _c2py_fun_0.doc(R"DOC()DOC");
 static const auto _c2py_doc_1 = _c2py_fun_1.doc(R"DOC()DOC");
@@ -52,6 +58,8 @@ static const auto _c2py_doc_3 = _c2py_fun_3.doc(R"DOC()DOC");
 static const auto _c2py_doc_4 = _c2py_fun_4.doc(R"DOC()DOC");
 static const auto _c2py_doc_5 = _c2py_fun_5.doc(R"DOC()DOC");
 static const auto _c2py_doc_6 = _c2py_fun_6.doc(R"DOC()DOC");
+static const auto _c2py_doc_7 = _c2py_fun_7.doc(R"DOC()DOC");
+static const auto _c2py_doc_8 = _c2py_fun_8.doc(R"DOC()DOC");
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {
@@ -59,9 +67,11 @@ static PyMethodDef module_methods[] = {
    {"identity_int16", (PyCFunction)c2py::pyfkw<_c2py_fun_1>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_1.c_str()},
    {"identity_int32", (PyCFunction)c2py::pyfkw<_c2py_fun_2>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_2.c_str()},
    {"identity_int64", (PyCFunction)c2py::pyfkw<_c2py_fun_3>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_3.c_str()},
-   {"identity_uint16", (PyCFunction)c2py::pyfkw<_c2py_fun_4>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_4.c_str()},
-   {"identity_uint32", (PyCFunction)c2py::pyfkw<_c2py_fun_5>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_5.c_str()},
-   {"identity_uint64", (PyCFunction)c2py::pyfkw<_c2py_fun_6>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_6.c_str()},
+   {"identity_int64_with_defarg", (PyCFunction)c2py::pyfkw<_c2py_fun_4>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_4.c_str()},
+   {"identity_uint16", (PyCFunction)c2py::pyfkw<_c2py_fun_5>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_5.c_str()},
+   {"identity_uint32", (PyCFunction)c2py::pyfkw<_c2py_fun_6>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_6.c_str()},
+   {"identity_uint64", (PyCFunction)c2py::pyfkw<_c2py_fun_7>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_7.c_str()},
+   {"identity_uint64_with_defarg", (PyCFunction)c2py::pyfkw<_c2py_fun_8>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_8.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 


### PR DESCRIPTION
- with brace initialization narrowing can lead to compiler errors
- add test
  - where narrowing is an issue
  - that checks handling of unqualified default argument types (see https://github.com/flatironinstitute/clair/pull/15)