### PR TITLE
Inherited properties from ignored base class

### DIFF
--- a/src/c2py/dyn_dispatch/dispatcher.hpp
+++ b/src/c2py/dyn_dispatch/dispatcher.hpp
@@ -76,6 +76,15 @@ namespace c2py {
     return ovs(self, nullptr, nullptr);
   }
 
+  // Same as setter_from_method, but for inherited methods where F has base class type.
+  // Cls is the derived class that we are wrapping.
+  template <typename Cls, auto F> static int setter_from_method_B(PyObject *self, PyObject *value, void *closure) {
+    if (value == nullptr) return (PyErr_SetString(PyExc_AttributeError, static_cast<const char *>(closure)), -1);
+    static c2py::dispatcher_f_kw_t d = {c2py::cfun_B<Cls>(F, "i")};
+    d(self, c2py::pyref(PyTuple_Pack(1, value)), nullptr);
+    return 0;
+  }
+
   // Setter from a method pointer.
   // closure must point to the attribute-name C-string used in the "cannot delete" error.
   template <auto F> static int setter_from_method(PyObject *self, PyObject *value, void *closure) {

--- a/src/c2py/dyn_dispatch/dispatcher.hpp
+++ b/src/c2py/dyn_dispatch/dispatcher.hpp
@@ -63,6 +63,13 @@ namespace c2py {
     return ovs(self, nullptr, nullptr);
   }
 
+  // Same as getter_from_method, but for inherited methods where M has base class type.
+  // Cls is the derived class that we are wrapping.
+  template <typename Cls, auto M> static PyObject *getter_from_method_B(PyObject *self, void *) {
+    static c2py::dispatcher_f_kw_t ovs = {c2py::cfun_B<Cls>(M)};
+    return ovs(self, nullptr, nullptr);
+  }
+
   // Getter from a free function whose first argument is self
   template <auto F> static PyObject *getter_from_fun(PyObject *self, void *) {
     static c2py::dispatcher_f_kw_t ovs = {c2py::cmethod(F, "self")};

--- a/test/cls_der.cpp
+++ b/test/cls_der.cpp
@@ -13,4 +13,15 @@ struct A : B {
   int a(int i, int j) { return i + j; }
 };
 
+class C2PY_IGNORE C {
+  int ic = 12;
+  public:
+  C(int i) : ic(i) {}
+  C2PY_PROPERTY_GET(cc) int cc() const { return ic; }
+};
+
+struct D : public C {
+  D(int i) : C(i) {}
+};
+
 #include "cls_der.wrap.cxx"

--- a/test/cls_der.cpp
+++ b/test/cls_der.cpp
@@ -18,6 +18,7 @@ class C2PY_IGNORE C {
   public:
   C(int i) : ic(i) {}
   C2PY_PROPERTY_GET(cc) int cc() const { return ic; }
+  C2PY_PROPERTY_SET(cc) void set_cc(int v) { ic = v; }
 };
 
 struct D : public C {

--- a/test/cls_der.wrap.cxx
+++ b/test/cls_der.wrap.cxx
@@ -73,6 +73,32 @@ PyMethodDef c2py::tp_methods<_c2py_cls_1>[] = {
 };
 
 template <> const std::string c2py::tp_doc<_c2py_cls_1> = R"DOC()DOC" + c2py::tp_ctor_doc<_c2py_cls_1>;
+// --------- class _c2py_cls_2 -----------
+using _c2py_cls_2                                            = D;
+template <> constexpr bool c2py::is_wrapped<_c2py_cls_2>     = true;
+template <> inline constexpr auto c2py::tp_name<_c2py_cls_2> = "cls_der.D";
+static auto _c2py_init_2                                     = c2py::dispatcher_c_kw_t{c2py::c_constructor<_c2py_cls_2, int>("i")};
+template <> constexpr initproc c2py::tp_init<_c2py_cls_2>    = c2py::pyfkw_constructor<_c2py_init_2>;
+template <> const std::string c2py::tp_ctor_doc<_c2py_cls_2> = _c2py_init_2.doc(R"DOC()DOC");
+
+// ----- Method table ----
+template <>
+PyMethodDef c2py::tp_methods<_c2py_cls_2>[] = {
+
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+static constexpr auto prop_doc_0 = R"DOC()DOC";
+
+// ----- Member and property table ----
+
+template <>
+constinit PyGetSetDef c2py::tp_getset<_c2py_cls_2>[] = {
+
+   {"cc", c2py::getter_from_method_B<D, c2py::castmc<>(&C::cc)>, nullptr, prop_doc_0, nullptr},
+   {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+template <> const std::string c2py::tp_doc<_c2py_cls_2> = R"DOC()DOC" + c2py::tp_ctor_doc<_c2py_cls_2>;
 
 // ==================== module functions ====================
 
@@ -113,6 +139,7 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_cls_der() {
   if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_0>) < 0) return NULL;
   c2py::wrap_pytype<_c2py_cls_1>.tp_base = &c2py::wrap_pytype<B>;
   if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_1>) < 0) return NULL;
+  if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_2>) < 0) return NULL;
 
   m = PyModule_Create(&module_def);
   if (m == NULL) return NULL;
@@ -123,6 +150,7 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_cls_der() {
 #define _add_type(T, N) c2py::add_type_object_to_main<T>(N, m, conv_table)
   _add_type(_c2py_cls_0, "B");
   _add_type(_c2py_cls_1, "A");
+  _add_type(_c2py_cls_2, "D");
 #undef _add_type
 
   return m;

--- a/test/cls_der.wrap.cxx
+++ b/test/cls_der.wrap.cxx
@@ -95,7 +95,8 @@ static constexpr auto prop_doc_0 = R"DOC()DOC";
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_2>[] = {
 
-   {"cc", c2py::getter_from_method_B<D, c2py::castmc<>(&C::cc)>, nullptr, prop_doc_0, nullptr},
+   {"cc", c2py::getter_from_method_B<D, c2py::castmc<>(&C::cc)>, (setter)c2py::setter_from_method_B<D, &C::set_cc>, prop_doc_0,
+    (void *)"Cannot delete the attribute cc"},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
 template <> const std::string c2py::tp_doc<_c2py_cls_2> = R"DOC()DOC" + c2py::tp_ctor_doc<_c2py_cls_2>;

--- a/test/cls_der.wrap.hxx
+++ b/test/cls_der.wrap.hxx
@@ -6,4 +6,6 @@ template <> constexpr bool c2py::is_wrapped<B>     = true;
 template <> inline constexpr auto c2py::tp_name<B> = "cls_der.B";
 template <> constexpr bool c2py::is_wrapped<A>     = true;
 template <> inline constexpr auto c2py::tp_name<A> = "cls_der.A";
+template <> constexpr bool c2py::is_wrapped<D>     = true;
+template <> inline constexpr auto c2py::tp_name<D> = "cls_der.D";
 #endif

--- a/test/cls_der_test.py
+++ b/test/cls_der_test.py
@@ -20,6 +20,8 @@ class TestInheritance(unittest.TestCase):
    def test_property(self):
         d = M.D(5)
         self.assertEqual(d.cc, 5)
+        d.cc = 10
+        self.assertEqual(d.cc, 10)
 
 #
 if __name__ == '__main__':

--- a/test/cls_der_test.py
+++ b/test/cls_der_test.py
@@ -6,7 +6,7 @@ import cls_der as M
 A = M.A
 B = M.B
 
-class TestIterable(unittest.TestCase):
+class TestInheritance(unittest.TestCase):
 
    def test_construct(self):
         a = M.A(2)
@@ -16,6 +16,10 @@ class TestIterable(unittest.TestCase):
         self.assertEqual( a.b(1),  3)
         self.assertTrue(isinstance(a, B))
         self.assertFalse(isinstance(b, A))
+
+   def test_property(self):
+        d = M.D(5)
+        self.assertEqual(d.cc, 5)
 
 #
 if __name__ == '__main__':


### PR DESCRIPTION
This is an attempt to handle inherited properties from ignored base classes.
I introduced an additional function `getter_from_method_B`. One probably can do something similar for setters.