### PR TITLE
Treat lshift op like in-place ops

### DIFF
--- a/src/c2py/pytypes/arithmetic.hpp
+++ b/src/c2py/pytypes/arithmetic.hpp
@@ -105,7 +105,7 @@ namespace c2py {
      0,                                             //     unaryfunc nb_absolute;
      0,                                             //     inquiry nb_bool;
      0,                                             //     unaryfunc nb_invert;
-     tp_number_impl<T, OpName::LShift>,             //     binaryfunc nb_lshift;
+     tp_number_impl<T, OpName::LShift, true>,        //     binaryfunc nb_lshift;
      0,                                             //     binaryfunc nb_rshift;
      0,                                             //     binaryfunc nb_and;
      0,                                             //     binaryfunc nb_xor;

--- a/test/arithmetic.cpp
+++ b/test/arithmetic.cpp
@@ -15,7 +15,7 @@ A operator/(A const &x, int y) { return A{x.k / y}; }
 A operator-(A const &x) { return A{-x.k}; }
 
 // Left shift
-A operator<<(A const &x, int n) { return A{x.k << n}; }
+A &operator<<(A &x, int n) { x.k += n; return x; }
 
 // In-place operators
 A &operator+=(A &x, A const &y) { x.k += y.k; return x; }

--- a/test/arithmetic_test.py
+++ b/test/arithmetic_test.py
@@ -37,8 +37,10 @@ class TestArithmetic(unittest.TestCase):
 
     def test_lshift(self):
         a = M.A(3)
-        b = a << 2
-        self.assertEqual(b.k, 12)
+        a << 2
+        self.assertEqual(a.k, 5)
+        a << 3 << 2
+        self.assertEqual(a.k, 10)
 
     def test_iadd(self):
         a = M.A(3)


### PR DESCRIPTION
- usually operator<< overloads return a reference
- allow chaining, i.e. foo << x << y
- modify arithmetic test

This PR goes hand in hand with https://github.com/flatironinstitute/clair/pull/20.