### PR TITLE
Add Hashable concept and tp_hash slot for wrapped-type __hash__

### DIFF
--- a/src/c2py/concepts4plugin.hpp
+++ b/src/c2py/concepts4plugin.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 #include "user_api.hpp"
 #include "py_converter.hpp"
 
@@ -29,5 +30,12 @@ namespace c2py::concepts {
 
   template <typename T>
   concept HasNonDeletedDefaultConstructor = std::is_default_constructible_v<T> && std::is_constructible_v<T>;
+
+  //---------------- Hashable-------------------
+  // A type is Hashable when std::hash<T> is specialized (the primary template is
+  // disabled by the standard, so the expression only compiles for specializations).
+  // Wrapped classes satisfying this concept opt into Python __hash__ via clair-c2py.
+  template <typename T>
+  concept Hashable = requires(T const &x) { std::hash<T>{}(x); };
 
 } // namespace c2py::concepts

--- a/src/c2py/pytypes/wrap.hpp
+++ b/src/c2py/pytypes/wrap.hpp
@@ -1,9 +1,11 @@
 #pragma once
+#include <functional>
 #include <sstream>
 #include <type_traits>
 
 #include "../util/str.hpp"
 #include "../py_converter.hpp"
+#include "../concepts4plugin.hpp"
 
 // local pieces, separated for code readibility
 #include "arithmetic.hpp"
@@ -50,7 +52,17 @@ namespace c2py {
   template <typename T> static constexpr ternaryfunc tp_call            = nullptr;
   template <typename T> static constinit PyMethodDef tp_methods[]       = {{nullptr, nullptr, 0, nullptr}}; //NOLINT
   template <typename T> static constexpr PyGetSetDef *tp_getset         = {nullptr};                        //NOLINT
+  template <typename T> static constexpr hashfunc tp_hash               = nullptr;
   // template <typename Cls> static PyObject *tp_richcompare(PyObject *a, PyObject *b, int op);
+
+  // tp_hash_impl : default implementation that dispatches to std::hash<T>.
+  // Clair-c2py emits a specialization `template <> constexpr hashfunc c2py::tp_hash<Cls> = c2py::tp_hash_impl<Cls>`
+  // for every wrapped class satisfying the c2py::concepts::Hashable concept.
+  template <concepts::Hashable Cls>
+  static constexpr hashfunc tp_hash_impl = [](PyObject *self) -> Py_hash_t {
+    auto h = static_cast<Py_hash_t>(std::hash<Cls>{}(py_converter<Cls>::py2c(self)));
+    return h == -1 ? -2 : h; // CPython reserves -1 for error signaling
+  };
 
   // --------------- The corresponding python object : wrap_pytype --------------------
 
@@ -70,7 +82,7 @@ namespace c2py {
         tp_as_number<T>,                          // tp_as_number
         0,                                        // tp_as_sequence
         &tp_as_mapping<T>,                        // tp_as_mapping
-        0,                                        // tp_hash
+        tp_hash<T>,                               // tp_hash
         tp_call<T>,                               // tp_call
         &tp_str<T>,                               // tp_str
         0,                                        // tp_getattro

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(c2py_all_full_tests
   tpl_derived
   callback
   std_container
+  hashable
   two_module_1
   two_module_2
   refcount

--- a/test/hashable.cpp
+++ b/test/hashable.cpp
@@ -1,0 +1,32 @@
+#include <c2py/c2py.hpp>
+#include <functional>
+
+namespace N {
+
+  struct cls_hashable {
+    int value = 0;
+
+    cls_hashable() = default;
+    explicit cls_hashable(int v) : value(v) {}
+
+    bool operator==(cls_hashable const &) const = default;
+  };
+
+  struct cls_not_hashable {
+    int value = 0;
+
+    cls_not_hashable() = default;
+    explicit cls_not_hashable(int v) : value(v) {}
+
+    bool operator==(cls_not_hashable const &) const = default;
+  };
+
+} // namespace N
+
+namespace std {
+  template <> struct hash<N::cls_hashable> {
+    std::size_t operator()(N::cls_hashable const &x) const noexcept { return std::hash<int>{}(x.value); }
+  };
+} // namespace std
+
+#include "hashable.wrap.cxx"

--- a/test/hashable.wrap.cxx
+++ b/test/hashable.wrap.cxx
@@ -1,0 +1,130 @@
+
+// C.f. https://numpy.org/doc/1.21/reference/c-api/array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL _cpp2py_ARRAY_API
+#ifndef CLAIR_C2PY_WRAP_GEN
+#ifdef __clang__
+// #pragma clang diagnostic ignored "-W#warnings"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
+
+#define C2PY_VERSION_MAJOR 0
+#define C2PY_VERSION_MINOR 1
+
+#include <c2py/c2py.hpp>
+
+using c2py::operator""_a;
+
+// ==================== enums =====================
+
+// ==================== module classes =====================
+
+// --------- class _c2py_cls_0 -----------
+using _c2py_cls_0                                            = N::cls_hashable;
+template <> constexpr bool c2py::is_wrapped<_c2py_cls_0>     = true;
+template <> inline constexpr auto c2py::tp_name<_c2py_cls_0> = "hashable.ClsHashable";
+template <> constexpr hashfunc c2py::tp_hash<_c2py_cls_0>    = c2py::tp_hash_impl<_c2py_cls_0>;
+static auto _c2py_init_0 = c2py::dispatcher_c_kw_t{c2py::c_constructor<_c2py_cls_0>(), c2py::c_constructor<_c2py_cls_0, int>("v")};
+template <> constexpr initproc c2py::tp_init<_c2py_cls_0>    = c2py::pyfkw_constructor<_c2py_init_0>;
+template <> const std::string c2py::tp_ctor_doc<_c2py_cls_0> = _c2py_init_0.doc(R"DOC()DOC");
+
+// ----- Method table ----
+template <>
+PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
+
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+constexpr auto _c2py_doc_member_0 = R"DOC()DOC";
+
+// ----- Member and property table ----
+
+template <>
+constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {c2py::getsetdef_from_member<&_c2py_cls_0::value, _c2py_cls_0>("value", _c2py_doc_member_0),
+
+                                                        {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+template <> const std::string c2py::tp_doc<_c2py_cls_0> = R"DOC()DOC" + c2py::tp_ctor_doc<_c2py_cls_0>;
+// --------- class _c2py_cls_1 -----------
+using _c2py_cls_1                                            = N::cls_not_hashable;
+template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
+template <> inline constexpr auto c2py::tp_name<_c2py_cls_1> = "hashable.ClsNotHashable";
+static auto _c2py_init_1 = c2py::dispatcher_c_kw_t{c2py::c_constructor<_c2py_cls_1>(), c2py::c_constructor<_c2py_cls_1, int>("v")};
+template <> constexpr initproc c2py::tp_init<_c2py_cls_1>    = c2py::pyfkw_constructor<_c2py_init_1>;
+template <> const std::string c2py::tp_ctor_doc<_c2py_cls_1> = _c2py_init_1.doc(R"DOC()DOC");
+
+// ----- Method table ----
+template <>
+PyMethodDef c2py::tp_methods<_c2py_cls_1>[] = {
+
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+constexpr auto _c2py_doc_member_1 = R"DOC()DOC";
+
+// ----- Member and property table ----
+
+template <>
+constinit PyGetSetDef c2py::tp_getset<_c2py_cls_1>[] = {c2py::getsetdef_from_member<&_c2py_cls_1::value, _c2py_cls_1>("value", _c2py_doc_member_1),
+
+                                                        {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+template <> const std::string c2py::tp_doc<_c2py_cls_1> = R"DOC()DOC" + c2py::tp_ctor_doc<_c2py_cls_1>;
+
+// ==================== module functions ====================
+
+//--------------------- module function table  -----------------------------
+
+static PyMethodDef module_methods[] = {
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+//--------------------- module struct & init error definition ------------
+
+//// module doc directly in the code or "" if not present...
+/// Or mandatory ?
+static struct PyModuleDef module_def = {PyModuleDef_HEAD_INIT,
+                                        "hashable",        /* name of module */
+                                        R"RAWDOC()RAWDOC", /* module documentation, may be NULL */
+                                        -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+                                        module_methods,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL};
+
+//--------------------- module init function -----------------------------
+
+extern "C" __attribute__((visibility("default"))) PyObject *PyInit_hashable() {
+
+  if (not c2py::check_python_version("hashable")) return NULL;
+
+  // import numpy iff 'numpy/arrayobject.h' included
+#ifdef Py_ARRAYOBJECT_H
+  import_array();
+#endif
+
+  PyObject *m;
+
+  if (PyType_Ready(&c2py::wrap_pytype<c2py::py_range>) < 0) return NULL;
+  if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_0>) < 0) return NULL;
+  if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_1>) < 0) return NULL;
+
+  m = PyModule_Create(&module_def);
+  if (m == NULL) return NULL;
+
+  auto &conv_table = *c2py::conv_table_sptr.get();
+
+  conv_table[std::type_index(typeid(c2py::py_range)).name()] = &c2py::wrap_pytype<c2py::py_range>;
+#define _add_type(T, N) c2py::add_type_object_to_main<T>(N, m, conv_table)
+  _add_type(_c2py_cls_0, "ClsHashable");
+  _add_type(_c2py_cls_1, "ClsNotHashable");
+#undef _add_type
+
+  return m;
+}
+#endif
+// CLAIR_WRAP_GEN

--- a/test/hashable.wrap.hxx
+++ b/test/hashable.wrap.hxx
@@ -1,0 +1,9 @@
+#include <c2py/c2py.hpp>
+
+#ifndef C2PY_HXX_DECLARATION_hashable_GUARDS
+#define C2PY_HXX_DECLARATION_hashable_GUARDS
+template <> constexpr bool c2py::is_wrapped<N::cls_hashable>         = true;
+template <> inline constexpr auto c2py::tp_name<N::cls_hashable>     = "hashable.ClsHashable";
+template <> constexpr bool c2py::is_wrapped<N::cls_not_hashable>     = true;
+template <> inline constexpr auto c2py::tp_name<N::cls_not_hashable> = "hashable.ClsNotHashable";
+#endif

--- a/test/hashable_test.py
+++ b/test/hashable_test.py
@@ -1,0 +1,33 @@
+import unittest
+
+from hashable import ClsHashable, ClsNotHashable
+
+
+class TestHashable(unittest.TestCase):
+
+    def test_hash_available(self):
+        a = ClsHashable(7)
+        b = ClsHashable(7)
+        c = ClsHashable(8)
+
+        # hash() returns an int and is consistent with equality
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsInstance(hash(a), int)
+        self.assertNotEqual(hash(a), hash(c))
+
+    def test_usable_as_dict_key(self):
+        d = {ClsHashable(1): "one", ClsHashable(2): "two"}
+        self.assertEqual(d[ClsHashable(1)], "one")
+        self.assertEqual(d[ClsHashable(2)], "two")
+
+    def test_usable_in_set(self):
+        s = {ClsHashable(5), ClsHashable(5), ClsHashable(6)}
+        self.assertEqual(len(s), 2)
+
+    def test_unhashable_still_unhashable(self):
+        with self.assertRaises(TypeError):
+            hash(ClsNotHashable(1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wrapped types are unhashable by default: `tp_hash` is hardcoded NULL in `wrap_pytype` while `tp_richcompare` is always set, so `PyType_Ready` marks instances as unhashable. This blocks pickle roundtrips that go through `std::map<K, V>` -> `PyDict` when `K` is a wrapped type (e.g. the map-based `__getstate__` path in triqs `Operator`).

Introduces a concept-based opt-in path, mirroring the existing `HasHdf5`/`Storable` pattern:

- `c2py::concepts::Hashable`, satisfied when `std::hash<T>` is specialized.
- A `tp_hash<T>` template slot (default `nullptr`) wired into `wrap_pytype`.
- `tp_hash_impl<T>` that dispatches to `std::hash<T>`, with the `-1 -> -2` remap to avoid CPython's error sentinel.

Clair-c2py emits a per-class template specialization of `tp_hash<T>` when the class satisfies `Hashable` (companion PR in clair: coming next). Types without `std::hash<T>` retain today's unhashable behavior.

## Test plan

- [x] New `test/hashable.cpp` / `hashable_test.py` fixture: one class with a `std::hash<T>` specialization (expected hashable), one without (expected `TypeError` from `hash()`).
- [x] Verifies `hash()` returns an `int`, use as dict key, set de-duplication, and that unhashable types stay unhashable.
- [x] Full c2py test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)