### PR TITLE
[cmake] Add c2py_add_module helper macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ endif()
 # Testing
 option(Build_Tests "Build tests" ON)
 
+# Regenerate the C++ Python bindings via clair-c2py for projects that use c2py_add_module.
+# Default OFF: most builds consume the checked-in .wrap.cxx files. Set ON when iterating on
+# bindings with clair installed.
+option(Update_Python_Bindings "Regenerate the C++ Python bindings via clair-c2py" OFF)
+
 # ############
 # Global Compilation Settings
 
@@ -125,10 +130,10 @@ endif()
 # Additional configuration files
 add_subdirectory(share)
 
-# Make the clair_c2py_generate_bindings function available to consumers
-# that pull c2py in as a subproject (e.g. via CPMAddPackage). For the
-# installed-package path it is included by c2py-config.cmake instead.
-include(${PROJECT_SOURCE_DIR}/share/cmake/clair_c2py_generate_bindings.cmake)
+# Make the c2py_add_module macro (and clair_c2py_generate_bindings) available
+# to consumers that pull c2py in as a subproject (e.g. via CPMAddPackage). For
+# the installed-package path it is included by c2py-config.cmake instead.
+include(${PROJECT_SOURCE_DIR}/share/cmake/c2py_add_module.cmake)
 
 #--------------------------------------------------------
 #   Sanitizers

--- a/share/cmake/CMakeLists.txt
+++ b/share/cmake/CMakeLists.txt
@@ -5,6 +5,7 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/c2py-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/c2py-config-version.cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/clair_c2py_generate_bindings.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/c2py_add_module.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/c2py
 )
 

--- a/share/cmake/c2py-config.cmake.in
+++ b/share/cmake/c2py-config.cmake.in
@@ -21,8 +21,8 @@ endif()
 # include the exported targets of this project
 include(@CMAKE_INSTALL_FULL_LIBDIR@/cmake/c2py/c2py-targets.cmake)
 
-# include the clair_c2py_generate_bindings function
-include(@CMAKE_INSTALL_FULL_LIBDIR@/cmake/c2py/clair_c2py_generate_bindings.cmake)
+# include the c2py_add_module macro (also includes clair_c2py_generate_bindings)
+include(@CMAKE_INSTALL_FULL_LIBDIR@/cmake/c2py/c2py_add_module.cmake)
 
 #SET(C2PY_C2PY_MODULE_EXTENSION "wrap.cxx")
 

--- a/share/cmake/c2py_add_module.cmake
+++ b/share/cmake/c2py_add_module.cmake
@@ -1,0 +1,44 @@
+include_guard(GLOBAL)
+include("${CMAKE_CURRENT_LIST_DIR}/clair_c2py_generate_bindings.cmake")
+
+# c2py_add_module(<name>
+#                 [DIR <relative-dir>]
+#                 [LINK_LIBRARIES <lib1> ...]
+#                 [DEPENDS_ON_BINDINGS <module1> ...])
+#
+# Builds <DIR>/<name>.cpp into a Python module with the SOABI suffix
+# and wires up clair-c2py binding generation (gated by
+# Update_Python_Bindings). DEPENDS_ON_BINDINGS names existing module
+# targets whose bindings must be generated first; non-binding targets
+# are skipped. For other orderings, use add_dependencies(${name} ...).
+#
+# Macro, not function: find_package(Python) must land in the caller's
+# scope or Python_add_library WITH_SOABI silently drops the suffix.
+macro(c2py_add_module _c2py_name)
+  cmake_parse_arguments(_c2py "" "DIR" "LINK_LIBRARIES;DEPENDS_ON_BINDINGS" ${ARGN})
+  find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
+
+  set(_c2py_src "${_c2py_name}.cpp")
+  if(_c2py_DIR)
+    set(_c2py_src "${_c2py_DIR}/${_c2py_src}")
+  endif()
+
+  Python_add_library(${_c2py_name} MODULE WITH_SOABI "${_c2py_src}")
+  set_target_properties(${_c2py_name} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${_c2py_DIR}"
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+  target_link_libraries(${_c2py_name} PRIVATE c2py::c2py ${_c2py_LINK_LIBRARIES})
+
+  if(Update_Python_Bindings)
+    clair_c2py_generate_bindings(${_c2py_name} DIR "${_c2py_DIR}")
+    foreach(_dep ${_c2py_DEPENDS_ON_BINDINGS})
+      if(NOT TARGET ${_dep})
+        message(FATAL_ERROR "c2py_add_module(${_c2py_name}): DEPENDS_ON_BINDINGS target '${_dep}' does not exist")
+      endif()
+      if(TARGET ${_dep}_bindings_generation)
+        add_dependencies(${_c2py_name}_bindings_generation ${_dep}_bindings_generation)
+      endif()
+    endforeach()
+  endif()
+endmacro()


### PR DESCRIPTION
## Summary

Adds a `c2py_add_module` helper macro that bundles the boilerplate for building a Python extension module from a single `.cpp` source:

- `find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)` in the caller's scope (the macro form is load-bearing here — `Python_SOABI` has to be set in the scope where `Python_add_library` runs)
- `Python_add_library(... MODULE WITH_SOABI ...)` so modules ship as `<name>.cpython-<ver>-<plat>.so` instead of bare `<name>.so`
- Hidden visibility (`CXX_VISIBILITY_PRESET hidden` + `VISIBILITY_INLINES_HIDDEN ON`)
- `target_link_libraries(... PRIVATE c2py::c2py ${LINK_LIBRARIES})`
- `clair_c2py_generate_bindings()` gated by `Update_Python_Bindings`, with optional `DEPENDS_ON_BINDINGS` to order bindings generation across modules

This fixes the regression introduced in the cpp2py → c2py port where direct `Python_add_library(... MODULE ...)` calls produced bare `.so` files — both because consumers had to remember `WITH_SOABI` and because `find_package(Python)` in a subdirectory doesn't propagate `Python_SOABI` to the parent.

Exposed to consumers both ways:
- via `add_subdirectory` / `FetchContent` — included from c2py's top-level `CMakeLists.txt`
- via `find_package(c2py)` — included from the installed `c2py-config.cmake`

Downstream call-site changes live in companion PRs to h5, modest, app4triqs, and triqs.

## Update_Python_Bindings option

The `option(Update_Python_Bindings ...)` declaration lives in c2py's top-level `CMakeLists.txt` (not inside the macro file) and defaults to **OFF**. Rationale:

- Most builds (CI on non-regen platforms, users without clair installed) consume the checked-in `.wrap.cxx` files. OFF is the right default for them.
- Putting the option in a project file rather than a macro file removes the side-effect-on-include surprise and decouples consumer overrides from `FetchContent` / `add_subdirectory` order.
- Consumers that want bindings regenerated pass `-DUpdate_Python_Bindings=ON` (typically the dedicated regen platform in CI).

## Usage

```cmake
c2py_add_module(<name>
                [DIR <relative-dir>]
                [LINK_LIBRARIES <lib1> ...]
                [DEPENDS_ON_BINDINGS <module1> ...])
```

`DEPENDS_ON_BINDINGS` takes existing module targets (not the internal `<name>_bindings_generation` targets); non-binding targets are silently skipped, so it's safe to pass a module built with `Update_Python_Bindings=OFF`.

## Test plan

- [x] c2py builds, ctest green locally
- [x] h5 builds via FetchContent override (`-DFETCHCONTENT_SOURCE_DIR_C2PY=...`); `_h5py` and `storable` ship as `.cpython-313-darwin.so`; 19/19 ctests pass
- [x] triqs builds the same way; all 22 Python modules ship with SOABI suffix; 362/362 ctests pass
- [ ] CI green